### PR TITLE
Registering from filepath bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# Abstract Factories
-
-[![Actions Status](https://github.com/ldunham1/abstract_factories/actions/workflows/python-package.yml/badge.svg)](https://github.com/ldunham1/abstract_factories/actions)
-[![Actions Status](https://github.com/ldunham1/abstract_factories/actions/workflows/pypi_publish.yml/badge.svg)](https://github.com/ldunham1/abstract_factories/actions)
+# Abstract Factories 
+[![PyPI - Version](https://img.shields.io/pypi/v/abstract-factories)](https://pypi.org/project/abstract-factories/) [![Actions Status](https://github.com/ldunham1/abstract_factories/actions/workflows/python-package.yml/badge.svg)](https://github.com/ldunham1/abstract_factories/actions)
 
 A collection of classes to support the Abstract Factory design pattern, providing a clear abstraction 
 layer for scalable data in dynamic environments.  
@@ -9,7 +7,7 @@ layer for scalable data in dynamic environments.
 `abstract_factories` will auto-register viable items from any given python **module** and/or **path**.  
 
 
-- Tested on Python 3.8 - 3.12
+- Tested on Python 3.7 - 3.12
 - Functional on Python 2.7
   > Wait - what? Python 2.7? What year is this?  
   > I often work professionally on legacy systems that are too 
@@ -27,7 +25,7 @@ pip install abstract-factories
 ---
 
 ## Usage
-Initialize AbstractTypeFactory or AbstractInstanceFactory with the abstract type.  
+Initialize AbstractTypeFactory or AbstractInstanceFactory with an abstract type.  
 Optionally, provide the attribute/method name to identify items by name (and optionally version).
 
 Registering items can be done directly.
@@ -48,8 +46,10 @@ type_factory.register_item(Car)
 assert type_factory.get('Car') is Car
 ```
 
+By default, items are referred to by class name, unless a name_key is provided.
 
-Or automatically by providing python modules or paths in which the factory can search.
+
+Abstract factories can automatically register items found in given python modules or paths.
 ```python
 from abstract_factories import AbstractTypeFactory
 from . import my_vehicle_package
@@ -66,7 +66,7 @@ type_factory.register_path('c:/Users/user/downloads/other_vehicles')
 ```
 
 
-In some use-cases, instances are a much better fit for the type of data you want to use in your factory.  
+In some use-cases, instances are a much better fit for the type of data you want to use in your factory (a factory of factories?).  
 In that case, use `AbstractInstanceFactory`.
 ```python
 from abstract_factories import AbstractInstanceFactory
@@ -88,7 +88,6 @@ instance_factory = AbstractInstanceFactory(AbstractVehicle, name_key='make')
 instance_factory.register_item(honda)
 assert instance_factory.get('Honda') is honda
 ```
-
 
 ### Registration:
 Register viable items directly.
@@ -157,6 +156,15 @@ builder.build([
     {'type': 'IKChainComponent', 'name': 'leg', 'version': 2},
 ])
 ```
+
+## Advanced: 
+These topics are for more advanced usage of `abstract_factories`.
+
+### Contextual `get`:
+Instead of a `str` type `name_key` or `version_key` value, you can instead provide a callable. This will be used to 
+determine each item's name and/or version.  
+This is especially useful when the context of an item's name or version lies outside the Factory's remit.  
+> ! Warning: A conditional `name_key` or `version_key` may result in unexpected behaviour if not managed correctly.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Abstract Factories
+
+[![Actions Status](https://github.com/ldunham1/abstract_factories/actions/workflows/python-package.yml/badge.svg)](https://github.com/ldunham1/abstract_factories/actions)
+[![Actions Status](https://github.com/ldunham1/abstract_factories/actions/workflows/pypi_publish.yml/badge.svg)](https://github.com/ldunham1/abstract_factories/actions)
+
 A collection of classes to support the Abstract Factory design pattern, providing a clear abstraction 
 layer for scalable data in dynamic environments.  
 

--- a/abstract_factories/core.py
+++ b/abstract_factories/core.py
@@ -4,10 +4,6 @@ import types
 from . import utils
 from .constants import LOGGER, FactoryItemModes
 
-# noinspection PyUnreachableCode
-if False:
-    from types import FunctionType
-
 
 # ------------------------------------------------------------------------------
 class _AbstractFactory(object):
@@ -19,10 +15,10 @@ class _AbstractFactory(object):
     :param type abstract: Abstract type to use. Only subclasses of this type will be supported.
     :param list[str]|str|None paths: Path(s) to immediately find abstracts in. Search is recursive.
     :param list[ModuleType]|ModuleType|None modules: Module(s) to immediately find abstracts in. Search is surface level.
-    :param str|FunctionType name_key: Item name identifier. Defaults to class name.
+    :param str|Callable name_key: Item name identifier. Defaults to class name.
         If str given, will get the item's value for that attribute, property or method.
         If callable given, will expect the callable to accept the item as an argument and will use the returned value.
-    :param str|FunctionType|None version_key: Item version identifier. Defaults to None, where versioning is not supported.
+    :param str|Callable|None version_key: Item version identifier. Defaults to None, where versioning is not supported.
         If str given, will get the item's value for that attribute, property or method.
         If callable given, will expect the callable to accept the item as an argument and will use the returned value.
         If None given, versioning will not be supported (first registered item will only be used).
@@ -301,10 +297,10 @@ class AbstractTypeFactory(_AbstractFactory):
     :param type abstract: Abstract type to use. Only subclasses of this type will be supported.
     :param list[str]|str|None paths: Path(s) to immediately find abstracts in. Search is recursive.
     :param list[ModuleType]|ModuleType|None modules: Module(s) to immediately find abstracts in. Search is surface level.
-    :param str|FunctionType name_key: Item name identifier. Defaults to class name.
+    :param str|Callable name_key: Item name identifier. Defaults to class name.
         If str given, will get the item's value for that attribute, property or method.
         If callable given, will expect the callable to accept the item as an argument and will use the returned value.
-    :param str|FunctionType|None version_key: Item version identifier. Defaults to None, where versioning is not supported.
+    :param str|Callable|None version_key: Item version identifier. Defaults to None, where versioning is not supported.
         If str given, will get the item's value for that attribute, property or method.
         If callable given, will expect the callable to accept the item as an argument and will use the returned value.
         If None given, versioning will not be supported (first registered item will only be used).
@@ -339,10 +335,10 @@ class AbstractInstanceFactory(_AbstractFactory):
     :param type abstract: Abstract type to use. Only subclasses of this type will be supported.
     :param list[str]|str|None paths: Path(s) to immediately find abstracts in. Search is recursive.
     :param list[ModuleType]|ModuleType|None modules: Module(s) to immediately find abstracts in. Search is surface level.
-    :param str|FunctionType name_key: Item name identifier. Defaults to class name.
+    :param str|Callable name_key: Item name identifier. Defaults to class name.
         If str given, will get the item's value for that attribute, property or method.
         If callable given, will expect the callable to accept the item as an argument and will use the returned value.
-    :param str|FunctionType|None version_key: Item version identifier. Defaults to None, where versioning is not supported.
+    :param str|Callable|None version_key: Item version identifier. Defaults to None, where versioning is not supported.
         If str given, will get the item's value for that attribute, property or method.
         If callable given, will expect the callable to accept the item as an argument and will use the returned value.
         If None given, versioning will not be supported (first registered item will only be used).

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as fh:
 setup(
     name='abstract_factories',
     packages=['abstract_factories'],
-    version='0.3.1',
+    version='0.4.0',
     license='MIT',
     description='Abstract Factory design pattern classes for scalable data in dynamic environments.',
     long_description=long_description,


### PR DESCRIPTION
Fixes #13 
Issue cause by inappropriate regex pattern relying on re.match for filenames being tested on a complete filepath.