### PR TITLE
Support registering files that use relative imports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,39 @@
 # Abstract Factories 
-[![PyPI - Version](https://img.shields.io/pypi/v/abstract-factories)](https://pypi.org/project/abstract-factories/) [![Actions Status](https://github.com/ldunham1/abstract_factories/actions/workflows/python-package.yml/badge.svg)](https://github.com/ldunham1/abstract_factories/actions)
+[![PyPI - Version](https://img.shields.io/pypi/v/abstract-factories)](https://pypi.org/project/abstract-factories/) [![Actions Status](https://github.com/ldunham1/abstract_factories/actions/workflows/python-package.yml/badge.svg)](https://github.com/ldunham1/abstract_factories/actions)  
 
-A collection of classes to support the Abstract Factory design pattern, providing a clear abstraction 
-layer for scalable data in dynamic environments.  
+![Python 2.7 Version](https://img.shields.io/badge/python-2.7-blue)
+![Python 3 Versions](https://img.shields.io/pypi/pyversions/pybadges.svg)
 
-`abstract_factories` will auto-register viable items from any given python **module** and/or **path**.  
+A collection of classes to support [Abstract Factory](https://refactoring.guru/design-patterns/abstract-factory) 
+design, but with convenience.  
+The Abstract Factory design lends itself well to systems that need to scale quickly and safely.  
 
 
-- Tested on Python 3.7 - 3.12
-- Functional on Python 2.7
-  > Wait - what? Python 2.7? What year is this?  
-  > I often work professionally on legacy systems that are too 
-  > fragile or large to update.
-  > Providing there's no functional or notable impact 
-  > supporting 2.7, I have no reason to ignore its existence _yet_.
 
----
+#### Simple Examples
+
+##### Rigging Framework
+See example [rig factory](https://github.com/ldunham1/abstract_factories/tree/main/examples/rig_factory).  
+Rig components can often be updated to address bugs, improve performance or introduce features.  
+A common unintentional side effect is introducing behavioural regressions or different results.  
+
+This approach encourages the use of versioning to "soft-lock" rig components so when a change is necessary, it 
+can be done whilst maintaining the current implementation. The new rig component version is used by default, but 
+the previous versions are still immediately accessible for use. 
+Better yet, the Abstract Factory design simplifies serialization and deserialization of the data, so older 
+rigs can still be built as they were whilst being aware of the potential to upgrade.
+
+
+##### Asset Validation (Files, Rigs, Models, Animations etc)
+See [simple_validation](https://github.com/ldunham1/abstract_factories/tree/main/examples/simple_validation) example.  
+Asset validation is relatively simple to implement, but increasingly difficult to manage during a production.  
+
+
 
 ## Installation
-```bash
-pip install abstract-factories
-```
+Clone this repo or access it from PyPI;  
+`pip install abstract-factories`
 
----
 
 ## Usage
 Initialize AbstractTypeFactory or AbstractInstanceFactory with an abstract type.  
@@ -109,46 +120,18 @@ import. Some limitation using relative imports.
 - `type_factory/instance_factory.register_path(r'c:/tools/tool_plugins')`
 - `type_factory/instance_factory.register_path(r'c:/tools/tool_plugins/plugin.py')`
 
----
 
-## Practical Applications
-Some examples of practical applications for `abstract_factories` in a production environment.
-
-### Data Validation and Contextual Modification
-Use multiple factories together to design scalable Validation, Publishing, Batching, Playlist 
-etc frameworks.  
-The simplicity of this design allows for quick iteration during development, conditional 
-validation, scalability and more.  
-See the [simple_validation](examples/simple_validation) example.
-
-
-### Content Creation - Rigging
-Useful for managing production needs in Film, TV, and Games, allowing easy modifications and versioning of components.  
-Easily support and modify rig component behaviours during production.  
-See the [rig_factory](examples/rig_factory) example.
-
-## Advanced: 
-These topics are for more advanced usage of `abstract_factories`.
+## Additional
 
 ### Contextual `get`:
 Instead of a `str` type `name_key` or `version_key` value, you can instead provide a callable. This will be used to 
 determine each item's name and/or version.  
 This is especially useful when the context of an item's name or version lies outside the Factory's remit.  
-> ! Warning: A conditional `name_key` or `version_key` may result in unexpected behaviour if not managed correctly.
 
----
-
-## Testing
-`.tests/` directory contains examples for;
-- Adding, removing & comparing items directly.
-- Adding, removing & comparing items found in modules and/or paths.
-
----
 
 ## Further Information
 Abstract factories is influenced by https://github.com/mikemalinowski/factories.
 
----
 
 ## License
 This project is licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -4,35 +4,87 @@
 ![Python 2.7 Version](https://img.shields.io/badge/python-2.7-blue)
 ![Python 3 Versions](https://img.shields.io/pypi/pyversions/pybadges.svg)
 
-A collection of classes to support [Abstract Factory](https://refactoring.guru/design-patterns/abstract-factory) 
-design, but with convenience.  
-The Abstract Factory design lends itself well to systems that need to scale quickly and safely.  
+[Abstract Factory](https://refactoring.guru/design-patterns/abstract-factory) lends itself well to systems that 
+need to scale quickly and safely, allowing users to build and interact with code constructs through names.  
+Typically, additional functionality is required to ensure this design fits into a framework well, and even more work 
+to allow for speedy iteration and development.  
+
+`abstract_factories` is a collection of classes to support this design with those additional conveniences built-in.
+- automatic (dynamic) registration from paths or modules
+- simple or conditional querying
+- versioning  
+- type or instance items
+
+and more. 
 
 
+## Example Usage
 
-#### Simple Examples
+### Tool Versioning
+Imagine you have a simple action you want to apply, already using the Abstract Factory design.
+```python
+from .abstracts import ActionAbstract
 
-##### Rigging Framework
-See example [rig factory](https://github.com/ldunham1/abstract_factories/tree/main/examples/rig_factory).  
+class DemoAction(ActionAbstract):
+    Version = 1
+
+    def apply(self):
+        print('Applied Demo.')
+```
+
+You then need to create a new action that addresses a bug BUT its old behavior is still required in places.  
+You can use `abstract_factories` to provide the correct version contextually.
+```python
+from .abstracts import ActionAbstract
+
+class MyAction(ActionAbstract):
+    Version = 2
+
+    def apply(self):
+        logging.info('Applied Demo.')
+```
+
+Now we just create a tool factory and tell it where to find these tools.
+```python
+import abstract_factories
+from .abstracts import ActionAbstract
+from . import actions
+
+tool_factory = abstract_factories.AbstractTypeFactory(ActionAbstract, version_key='Version')
+tool_factory.register_module(actions)
+
+demo_action = tool_factory.get('DemoAction')  # Automatically retrieves latest.
+old_demo_action = tool_factory.get('DemoAction', version=1)
+```
+
+
+### Rigging Frameworks
+See [rig factory](https://github.com/ldunham1/abstract_factories/tree/main/examples/rig_factory).  
 Rig components can often be updated to address bugs, improve performance or introduce features.  
 A common unintentional side effect is introducing behavioural regressions or different results.  
 
-This approach encourages the use of versioning to "soft-lock" rig components so when a change is necessary, it 
-can be done whilst maintaining the current implementation. The new rig component version is used by default, but 
-the previous versions are still immediately accessible for use. 
+`abstract_factories` encourages the use of versioning to "soft-lock" components so when a change is necessary, it 
+can be done safely. The new rig component version is used by default, but the previous versions are still accessible at 
+the same time. 
 Better yet, the Abstract Factory design simplifies serialization and deserialization of the data, so older 
 rigs can still be built as they were whilst being aware of the potential to upgrade.
 
 
-##### Asset Validation (Files, Rigs, Models, Animations etc)
-See [simple_validation](https://github.com/ldunham1/abstract_factories/tree/main/examples/simple_validation) example.  
+### Validation Frameworks (Files, Rigs, Models, Animations etc)
+See [simple_validation](https://github.com/ldunham1/abstract_factories/tree/main/examples/simple_validation).  
 Asset validation is relatively simple to implement, but increasingly difficult to manage during a production.  
+Some validation frameworks, like [Pyblish](https://pyblish.com/) manages this well.  
 
+`abstract_factories` provides the minimum required to build your own similar Validation framework. Its 
+item auto-registration provides a very flexible environment to quickly develop, improve, iterate and scale 
+as you see fit.
 
 
 ## Installation
 Clone this repo or access it from PyPI;  
-`pip install abstract-factories`
+```bash
+pip install abstract-factories
+```
 
 
 ## Usage

--- a/abstract_factories/core.py
+++ b/abstract_factories/core.py
@@ -281,7 +281,7 @@ class _AbstractFactory(object):
         count = 0
 
         for filepath in utils.iter_python_files(path, recursive=recursive):
-            module = utils.import_from_filepath(filepath)
+            module = utils.import_from_path(filepath)
             if module:
                 count += self.register_module(module)
 

--- a/tests/test_abstract_factories_paths/__init__.py
+++ b/tests/test_abstract_factories_paths/__init__.py
@@ -14,7 +14,14 @@ except ImportError:
     from unittest.mock import StringIO
 
 
-subclass_directory = os.path.join(os.path.dirname(__file__), 'non_package_directory')
+directories = [
+    os.path.join(os.path.dirname(__file__), 'non_package_directory'),
+    # os.path.join(os.path.dirname(__file__), 'package_directory'),
+]
+filepaths = [
+    os.path.join(directory, 'vehicle.py')
+    for directory in directories
+]
 
 
 # ------------------------------------------------------------------------------
@@ -22,7 +29,7 @@ class TestVehicleTypeFactory(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=[subclass_directory])
+        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=directories)
 
     def test_get_car(self):
         car = self.VehicleFactory.get('Car')
@@ -81,7 +88,7 @@ class TestVehicleInstanceFactory(unittest.TestCase):
     def setUpClass(cls):
         cls.VehicleFactory = AbstractInstanceFactory(
             VehicleAbstract,
-            paths=[subclass_directory],
+            paths=directories,
             name_key='name',
             version_key='year',
         )
@@ -143,7 +150,7 @@ class TestVehicleTypeFilepathFactory(TestVehicleTypeFactory):
 
     @classmethod
     def setUpClass(cls):
-        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=[os.path.join(subclass_directory, 'vehicles.py')])
+        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=filepaths)
 
 
 class TestVehicleInstanceFilepathFactory(TestVehicleInstanceFactory):
@@ -152,7 +159,7 @@ class TestVehicleInstanceFilepathFactory(TestVehicleInstanceFactory):
     def setUpClass(cls):
         cls.VehicleFactory = AbstractInstanceFactory(
             VehicleAbstract,
-            paths=[os.path.join(subclass_directory, 'vehicles.py')],
+            paths=filepaths,
             name_key='name',
             version_key='year',
         )

--- a/tests/test_abstract_factories_paths/__init__.py
+++ b/tests/test_abstract_factories_paths/__init__.py
@@ -14,14 +14,7 @@ except ImportError:
     from unittest.mock import StringIO
 
 
-directories = [
-    os.path.join(os.path.dirname(__file__), 'non_package_directory'),
-    # os.path.join(os.path.dirname(__file__), 'package_directory'),
-]
-filepaths = [
-    os.path.join(directory, 'vehicle.py')
-    for directory in directories
-]
+subclass_directory = os.path.join(os.path.dirname(__file__), 'non_package_directory')
 
 
 # ------------------------------------------------------------------------------
@@ -29,7 +22,7 @@ class TestVehicleTypeFactory(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=directories)
+        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=[subclass_directory])
 
     def test_get_car(self):
         car = self.VehicleFactory.get('Car')
@@ -88,7 +81,7 @@ class TestVehicleInstanceFactory(unittest.TestCase):
     def setUpClass(cls):
         cls.VehicleFactory = AbstractInstanceFactory(
             VehicleAbstract,
-            paths=directories,
+            paths=[subclass_directory],
             name_key='name',
             version_key='year',
         )
@@ -150,7 +143,7 @@ class TestVehicleTypeFilepathFactory(TestVehicleTypeFactory):
 
     @classmethod
     def setUpClass(cls):
-        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=filepaths)
+        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=[os.path.join(subclass_directory, 'vehicles.py')])
 
 
 class TestVehicleInstanceFilepathFactory(TestVehicleInstanceFactory):
@@ -159,7 +152,7 @@ class TestVehicleInstanceFilepathFactory(TestVehicleInstanceFactory):
     def setUpClass(cls):
         cls.VehicleFactory = AbstractInstanceFactory(
             VehicleAbstract,
-            paths=filepaths,
+            paths=[os.path.join(subclass_directory, 'vehicles.py')],
             name_key='name',
             version_key='year',
         )

--- a/tests/test_abstract_factories_paths/__init__.py
+++ b/tests/test_abstract_factories_paths/__init__.py
@@ -14,7 +14,14 @@ except ImportError:
     from unittest.mock import StringIO
 
 
-subclass_directory = os.path.join(os.path.dirname(__file__), 'non_package_directory')
+directories = [
+    os.path.join(os.path.dirname(__file__), 'non_package_directory'),
+    # os.path.join(os.path.dirname(__file__), 'package_directory'),
+]
+filepaths = [
+    os.path.join(directory, 'vehicle.py')
+    for directory in directories
+]
 
 
 # ------------------------------------------------------------------------------
@@ -22,7 +29,7 @@ class TestVehicleTypeFactory(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=[subclass_directory])
+        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=directories)
 
     def test_get_car(self):
         car = self.VehicleFactory.get('Car')
@@ -73,7 +80,7 @@ class TestVehicleInstanceFactory(unittest.TestCase):
     def setUpClass(cls):
         cls.VehicleFactory = AbstractInstanceFactory(
             VehicleAbstract,
-            paths=[subclass_directory],
+            paths=directories,
             name_key='name',
             version_key='year',
         )
@@ -126,7 +133,7 @@ class TestVehicleTypeFilepathFactory(TestVehicleTypeFactory):
 
     @classmethod
     def setUpClass(cls):
-        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=[os.path.join(subclass_directory, 'vehicles.py')])
+        cls.VehicleFactory = AbstractTypeFactory(VehicleAbstract, paths=filepaths)
 
 
 class TestVehicleInstanceFilepathFactory(TestVehicleInstanceFactory):
@@ -135,7 +142,7 @@ class TestVehicleInstanceFilepathFactory(TestVehicleInstanceFactory):
     def setUpClass(cls):
         cls.VehicleFactory = AbstractInstanceFactory(
             VehicleAbstract,
-            paths=[os.path.join(subclass_directory, 'vehicles.py')],
+            paths=filepaths,
             name_key='name',
             version_key='year',
         )

--- a/tests/test_abstract_factories_paths/package_directory/relative_vehicles.py
+++ b/tests/test_abstract_factories_paths/package_directory/relative_vehicles.py
@@ -1,0 +1,15 @@
+from .vehicles import Truck
+
+
+class PedaloTruck(Truck):
+
+    def start(self):
+        print("Starting {} {} pedalo.".format(self.year, self.make))
+
+    def stop(self):
+        print("Stopping {} {} pedalo.".format(self.year, self.make))
+
+
+# ------------------------------------------------------------------------------
+# Instances
+pedalo_truck1 = PedaloTruck('SunFun', 'Sand', 1989)

--- a/tests/test_abstract_factories_paths/package_directory/vehicles.py
+++ b/tests/test_abstract_factories_paths/package_directory/vehicles.py
@@ -1,0 +1,48 @@
+from test_abstract_factories_paths.abstract import VehicleAbstract
+
+
+class Car(VehicleAbstract):
+
+    def start(self):
+        print("Starting {} {} {} car.".format(self.year, self.make, self.model))
+
+    def stop(self):
+        print("Stopping {} {} {} car.".format(self.year, self.make, self.model))
+
+
+class Truck(VehicleAbstract):
+
+    def start(self):
+        print("Starting {} {} {} truck.".format(self.year, self.make, self.model))
+
+    def stop(self):
+        print("Stopping {} {} {} truck.".format(self.year, self.make, self.model))
+
+
+class Truck2(Truck):
+
+    def stop(self):
+        print('About to stop...')
+        super(Truck2, self).stop()
+
+
+class Motorcycle(VehicleAbstract):
+
+    def start(self):
+        print("Starting {} {} {} motorcycle.".format(self.year, self.make, self.model))
+
+    def stop(self):
+        print("Stopping {} {} {} motorcycle.".format(self.year, self.make, self.model))
+
+
+# ------------------------------------------------------------------------------
+# Instances
+car1 = Car('Toyota', 'Camry', 2020)
+car2 = Car('Ford', 'Fiesta', 1987)
+
+truck1 = Truck('Ford', 'F-150', 2018)
+truck2 = Truck2('Ford', 'F-150', 2020)
+
+motorcycle1 = Motorcycle('Honda', 'CBR', 2004)
+motorcycle2 = Motorcycle('Honda', 'CBR', 2008)
+motorcycle3 = Motorcycle('Yamaha', 'R3', 2012)


### PR DESCRIPTION
Fixes #25.
When registering a path, if its part of a package, it is imported using the package address (`sys.path` temporarily modified to support this).
This ensures any modules being loaded during path registration that use relative imports are supported.

This addresses a relatively notable functional improvement when registering paths as it now allows developers to work with larger packages.